### PR TITLE
자바 컴파일 인코딩을 설정하라

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,12 @@ asciidoctor {
     dependsOn test
 }
 
+[compileJava, compileTestJava, javadoc]*.options*.encoding = 'UTF-8'
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
 jacoco {
     toolVersion = "0.8.6"
 }


### PR DESCRIPTION
자바 문서(JavaDoc) 를 생성할 때 한글이 깨지는 오류가 있었습니다.